### PR TITLE
fail sphinx build on warning so Jenkins can report it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web/ /web/
 COPY docs/ /tmp/docs
 COPY plaid /src
 
-RUN sphinx-build /tmp/docs/source /web/docs \
+RUN sphinx-build -W /tmp/docs/source /web/docs \
  && rm -rf /src
 
 CMD python /web/main.py


### PR DESCRIPTION
Jenkins would pass a build, despite sphinx failing to render some templates, because sphinx treats them as warnings. `-W` flag fixes this.

https://stackoverflow.com/questions/32526150/how-to-deliberately-fail-a-sphinx-build-when-autodoc-fails-an-import